### PR TITLE
Makes Account type alias Public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polychat-plugin"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 
 description = "A library containing types required to make a polychat plugin"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use libc::c_void;
 
-type Account = *mut c_void;
+pub type Account = *mut c_void;
 
 extern "C" {
 	fn create_account() -> Account;


### PR DESCRIPTION
This makes the Account alias for a `*mut c_void` public for others to use in their types.

Incremented version number for release.